### PR TITLE
add fresh man's guide in ranking UI

### DIFF
--- a/rank/index.html
+++ b/rank/index.html
@@ -8,9 +8,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&family=Playfair+Display:ital,wght@0,500;1,500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../shared-nav.css">
-  <link rel="stylesheet" href="../shared/onboarding.css">
+  <link rel="stylesheet" href="./onboarding.css">
   <script src="../shared/acadbeat-local-config.js"></script>
-  <script src="../shared/onboarding.js"></script>
+  <script src="./onboarding.js"></script>
   <style>html.acadbeat-role-guard body{visibility:hidden}</style>
   <script>
     document.documentElement.classList.add('acadbeat-role-guard');
@@ -41,7 +41,8 @@
       <h1>Team Ranking</h1>
       <p>Weekly Challenge Team Performance</p>
       <div class="ranking-header__actions">
-        <button type="button" class="btn-primary rank-challenge-btn" id="rankWeeklyChallengeBtn">Weekly challenge</button>
+        <button type="button" class="btn-primary rank-challenge-btn" id="rankWeeklyChallengeBtn" data-guide-rank="challenge-btn">Weekly challenge</button>
+        <button type="button" class="btn-primary rank-guide-btn" id="rankGuideBtn" data-guide-rank="guide-btn" aria-label="Open ranking guide" title="Guide">?</button>
       </div>
     </div>
     

--- a/rank/onboarding.css
+++ b/rank/onboarding.css
@@ -1,0 +1,93 @@
+/* 新手指引样式 */
+.acadbeat-guide-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 9990;
+  pointer-events: none;
+}
+
+.acadbeat-guide-card {
+  position: fixed;
+  max-width: 400px;
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+  z-index: 9992;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  pointer-events: auto;
+}
+
+.acadbeat-guide-card h4 {
+  margin: 0 0 12px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.acadbeat-guide-card p {
+  margin: 0 0 16px 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #4a4a4a;
+}
+
+.acadbeat-guide-card__meta {
+  font-size: 12px;
+  color: #8a8a8a;
+  margin-bottom: 16px;
+}
+
+.acadbeat-guide-card__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.acadbeat-guide-btn {
+  padding: 6px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: white;
+  color: #374151;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.acadbeat-guide-btn:hover:not(:disabled) {
+  background: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.acadbeat-guide-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.acadbeat-guide-btn--primary {
+  background: #3b82f6;
+  color: white;
+  border-color: #3b82f6;
+}
+
+.acadbeat-guide-btn--primary:hover:not(:disabled) {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.acadbeat-guide-focus {
+  position: relative !important;
+  z-index: 9991 !important;
+  outline: 4px solid #3b82f6 !important;
+  outline-offset: 4px !important;
+  border-radius: 8px;
+  box-shadow: 0 0 0 12px rgba(59, 130, 246, 0.3) !important;
+}

--- a/rank/onboarding.js
+++ b/rank/onboarding.js
@@ -105,6 +105,12 @@
 
     next() {
       if (!this.active) return;
+      const currentStep = this.steps[this.index];
+      if (typeof currentStep.onNext === 'function') {
+        try {
+          currentStep.onNext();
+        } catch (_err) {}
+      }
       const nextIndex = this.index + 1;
       if (nextIndex >= this.steps.length) {
         this.stop(true);
@@ -162,7 +168,8 @@
       if (targetEl) {
         targetEl.classList.add(GUIDE_CLASS);
         try {
-          targetEl.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
+          // 只滚动到可见区域，不居中，避免影响弹窗定位
+          targetEl.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
         } catch (_err) {}
       }
 
@@ -208,6 +215,17 @@
       btnPrev?.addEventListener('click', () => this.prev());
       btnNext?.addEventListener('click', () => this.next());
 
+      // 确保卡片已经在DOM中
+      if (!document.body.contains(this.cardEl)) {
+        this.cardEl.style.position = 'fixed';
+        document.body.appendChild(this.cardEl);
+      }
+
+      // 先将卡片设置为可见，以便获取正确的尺寸
+      this.cardEl.style.visibility = 'hidden';
+      this.cardEl.style.opacity = '0';
+
+      // 现在获取正确的卡片尺寸
       const cardRect = this.cardEl.getBoundingClientRect();
       const vw = window.innerWidth;
       const vh = window.innerHeight;
@@ -216,45 +234,69 @@
       let left = Math.round((vw - cardRect.width) / 2);
 
       if (targetEl) {
-        const rect = targetEl.getBoundingClientRect();
-        const gap = 14;
-        const place = String(step.placement || 'bottom');
-        if (place === 'top') {
-          top = rect.top - cardRect.height - gap;
-          left = rect.left;
-        } else if (place === 'left') {
-          top = rect.top;
-          left = rect.left - cardRect.width - gap;
-        } else if (place === 'right') {
-          top = rect.top;
-          left = rect.right + gap;
+        // 检查是否是第二步（Weekly Challenge）
+        if (step.title && step.title.includes('Weekly Challenge')) {
+          // 强制显示在屏幕中央
+          console.log('Forcing center position for Weekly Challenge step');
         } else {
-          top = rect.bottom + gap;
-          left = rect.left;
-        }
-
-        // If this step requires clicking, avoid covering the target area.
-        if (step.requireClick) {
-          const targetCenterX = rect.left + (rect.width / 2);
-          const targetCenterY = rect.top + (rect.height / 2);
-          const fitsTop = rect.top >= (cardRect.height + gap + 10);
-          const fitsBottom = (vh - rect.bottom) >= (cardRect.height + gap + 10);
-          const fitsLeft = rect.left >= (cardRect.width + gap + 10);
-          const fitsRight = (vw - rect.right) >= (cardRect.width + gap + 10);
-
-          if (fitsTop) {
+          const rect = targetEl.getBoundingClientRect();
+          const gap = 14;
+          const place = String(step.placement || 'bottom');
+          
+          // 调试信息
+          console.log('Guide Step:', step.title);
+          console.log('Target Element:', targetEl);
+          console.log('Target Rect:', rect);
+          console.log('Card Rect:', cardRect);
+          console.log('Viewport Size:', { width: vw, height: vh });
+          
+          if (place === 'top') {
             top = rect.top - cardRect.height - gap;
-            left = targetCenterX - (cardRect.width / 2);
-          } else if (fitsBottom) {
-            top = rect.bottom + gap;
-            left = targetCenterX - (cardRect.width / 2);
-          } else if (fitsRight) {
-            top = targetCenterY - (cardRect.height / 2);
-            left = rect.right + gap;
-          } else if (fitsLeft) {
-            top = targetCenterY - (cardRect.height / 2);
+            left = rect.left;
+          } else if (place === 'left') {
+            top = rect.top;
             left = rect.left - cardRect.width - gap;
+          } else if (place === 'right') {
+            top = rect.top;
+            left = rect.right + gap;
+          } else {
+            top = rect.bottom + gap;
+            left = rect.left;
           }
+
+          // If this step requires clicking, avoid covering the target area.
+          if (step.requireClick) {
+            const targetCenterX = rect.left + (rect.width / 2);
+            const targetCenterY = rect.top + (rect.height / 2);
+            const fitsTop = rect.top >= (cardRect.height + gap + 10);
+            const fitsBottom = (vh - rect.bottom) >= (cardRect.height + gap + 10);
+            const fitsLeft = rect.left >= (cardRect.width + gap + 10);
+            const fitsRight = (vw - rect.right) >= (cardRect.width + gap + 10);
+            
+            // 调试信息
+            console.log('Fits Check:', { fitsTop, fitsBottom, fitsLeft, fitsRight });
+
+            if (fitsBottom) {
+              top = rect.bottom + gap;
+              left = targetCenterX - (cardRect.width / 2);
+              console.log('Placing below target');
+            } else if (fitsTop) {
+              top = rect.top - cardRect.height - gap;
+              left = targetCenterX - (cardRect.width / 2);
+              console.log('Placing above target');
+            } else if (fitsRight) {
+              top = targetCenterY - (cardRect.height / 2);
+              left = rect.right + gap;
+              console.log('Placing to the right of target');
+            } else if (fitsLeft) {
+              top = targetCenterY - (cardRect.height / 2);
+              left = rect.left - cardRect.width - gap;
+              console.log('Placing to the left of target');
+            }
+          }
+          
+          // 调试信息
+          console.log('Calculated Position:', { top, left });
         }
       }
 
@@ -262,6 +304,10 @@
       left = Math.max(10, Math.min(vw - cardRect.width - 10, left));
       this.cardEl.style.top = `${top}px`;
       this.cardEl.style.left = `${left}px`;
+      
+      // 最后将卡片设置为可见
+      this.cardEl.style.visibility = 'visible';
+      this.cardEl.style.opacity = '1';
     }
   }
 

--- a/rank/script.js
+++ b/rank/script.js
@@ -3,6 +3,7 @@ class TeamRanking {
     this.currentUser = null;
     this.teamData = null;
     this.rankingData = [];
+    this.guideRunnerRef = null;
     this.init();
   }
 
@@ -14,6 +15,8 @@ class TeamRanking {
     }
     this.renderMyTeam();
     this.renderRanking();
+    this.addDataGuideAttributes();
+    this.initGuideButton();
   }
 
   async getUserInfo() {
@@ -266,6 +269,106 @@ class TeamRanking {
     const div = document.createElement('div');
     div.textContent = text;
     return div.innerHTML;
+  }
+
+  getGuideUserId() {
+    return this.currentUser?.user_id || this.currentUser?.id || this.currentUser?.username || 'guest';
+  }
+
+  startRankingGuide(force = false) {
+    if (!window.AcadBeatGuide || !this.currentUser) {
+      return;
+    }
+
+    const guideKey = 'ranking-overview-v1';
+    const userId = this.getGuideUserId();
+    if (!force && window.AcadBeatGuide.hasSeen(guideKey, userId)) {
+      return;
+    }
+
+    window.setTimeout(() => {
+      if (this.guideRunnerRef) {
+        this.guideRunnerRef.stop(false);
+      }
+      const runner = window.AcadBeatGuide.create({
+        guideKey,
+        userId,
+        steps: [
+  {
+    target: '[data-guide-rank="my-team"]',
+    placement: 'right',
+    title: 'Step 1: My Team',
+    content: 'This section shows your team information, members, and progress.',
+  },
+  {
+    target: '[data-guide-rank="challenge-btn"]',
+    placement: 'bottom',
+    requireClick: true,
+    title: 'Step 2: Weekly Challenge',
+    content: 'Click here to join or create a team for the weekly challenge.',
+    beforeEnter: () => {
+      // 确保challenge按钮在视口中
+      const challengeBtn = document.querySelector('[data-guide-rank="challenge-btn"]');
+      if (challengeBtn) {
+        challengeBtn.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
+      }
+    }
+  },
+  {
+    target: () => document.querySelector('.challenge-panel-title') || document.querySelector('.challenge-hero'),
+    placement: 'bottom',
+    title: 'Step 3: Team Formation',
+    content: 'Here you can form a 4-person team for the challenge.',
+    onNext: () => {
+      // 直接关闭challenge面板
+      if (window.toggleTeamModal) {
+        window.toggleTeamModal(false);
+      }
+    }
+  },
+  {
+    target: '[data-guide-rank="ranking-list"]',
+    placement: 'left',
+    title: 'Step 4: Team Rankings',
+    content: 'See how your team ranks against others here.',
+  },
+  {
+    target: '[data-guide-rank="guide-btn"]',
+    placement: 'bottom',
+    title: 'Step 5: Guide Button',
+    content: 'Click the guide button anytime to see this tutorial again.',
+  },
+],
+      });
+      this.guideRunnerRef = runner;
+      runner.start();
+    }, 260);
+  }
+
+  initGuideButton() {
+    const guideBtn = document.getElementById('rankGuideBtn');
+    if (guideBtn) {
+      guideBtn.addEventListener('click', () => {
+        this.startRankingGuide(true);
+      });
+    }
+  }
+
+  addDataGuideAttributes() {
+    const myTeamCard = document.querySelector('.my-team-card');
+    if (myTeamCard) {
+      myTeamCard.setAttribute('data-guide-rank', 'my-team');
+    }
+
+    const progressItems = document.querySelectorAll('.team-progress');
+    progressItems.forEach((item, index) => {
+      item.setAttribute('data-guide-rank', 'progress');
+    });
+
+    const rankingList = document.querySelector('.ranking-list');
+    if (rankingList) {
+      rankingList.setAttribute('data-guide-rank', 'ranking-list');
+    }
   }
 }
 

--- a/rank/style.css
+++ b/rank/style.css
@@ -71,7 +71,6 @@
   --shadow-md: 0 4px 6px -1px rgba(91, 42, 134, 0.14), 0 2px 4px -1px rgba(91, 42, 134, 0.1);
   --shadow-lg: 0 10px 15px -3px rgba(91, 42, 134, 0.16), 0 4px 6px -2px rgba(91, 42, 134, 0.1);
   --border-radius: 8px;
-  --transition: all 0.3s ease;
 }
 
 * {
@@ -105,7 +104,6 @@ body::before {
   left: -16vw;
   top: -18vw;
   background: radial-gradient(circle, rgba(250, 204, 21, 0.26), transparent 72%);
-  animation: rankDriftA 11s ease-in-out infinite alternate;
 }
 
 body::after {
@@ -114,7 +112,6 @@ body::after {
   right: -12vw;
   bottom: -14vw;
   background: radial-gradient(circle, rgba(91, 42, 134, 0.24), transparent 72%);
-  animation: rankDriftB 13s ease-in-out infinite alternate;
 }
 
 /* Floating back to competition gate (replaces top breadcrumb bar) */
@@ -135,7 +132,6 @@ body::after {
   font-size: 0.88rem;
   font-weight: 700;
   text-decoration: none;
-  transition: var(--transition);
 }
 
 .rank-back-float:hover {
@@ -165,37 +161,19 @@ body::after {
   grid-template-columns: 480px 1fr;
   gap: 24px;
   align-items: start;
-  opacity: 0;
-  transform: translateY(20px);
-  animation: fadeInUp 0.8s ease-out forwards;
-  animation-delay: 0.2s;
-}
-
-/* Animation Keyframes */
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* Staggered Animation for Child Elements */
 .my-team-card {
-  animation: fadeInUp 0.8s ease-out forwards;
-  animation-delay: 0.4s;
-  opacity: 0;
-  transform: translateY(20px);
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .ranking-list {
-  animation: fadeInUp 0.8s ease-out forwards;
-  animation-delay: 0.6s;
-  opacity: 0;
-  transform: translateY(20px);
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* Header Styles */
@@ -203,30 +181,8 @@ body::after {
   text-align: center;
   margin-bottom: 32px;
   padding: 0 24px;
-  opacity: 0;
-  transform: translateY(-20px);
-  animation: fadeInDown 0.8s ease-out forwards;
-}
-
-@keyframes fadeInDown {
-  from {
-    opacity: 0;
-    transform: translateY(-20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes rankDriftA {
-  from { transform: translate3d(0, 0, 0) scale(1); }
-  to { transform: translate3d(4vw, 2vh, 0) scale(1.08); }
-}
-
-@keyframes rankDriftB {
-  from { transform: translate3d(0, 0, 0) scale(1); }
-  to { transform: translate3d(-3vw, -2vh, 0) scale(1.1); }
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .ranking-header h1 {
@@ -267,6 +223,35 @@ body::after {
   border: none;
   font: inherit;
   cursor: pointer;
+}
+
+.ranking-header .rank-guide-btn {
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  padding: 0;
+  border-radius: 50%;
+  font-size: 18px;
+  font-weight: bold;
+  background: rgba(255, 255, 255, 0.9);
+  color: #3a3a3a;
+  border: 1px solid #e0e0e0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.ranking-header .rank-guide-btn:hover {
+  background: rgba(255, 255, 255, 1);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  transform: translateY(-1px);
+}
+
+.ranking-header .rank-guide-btn:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 /* My Team Card */
@@ -337,7 +322,6 @@ body::after {
   gap: 16px;
   padding: 20px;
   border-bottom: 1px solid var(--border-color);
-  transition: var(--transition);
   align-items: center;
 }
 
@@ -586,7 +570,6 @@ body::after {
   height: 100%;
   background: var(--secondary-color);
   border-radius: 4px;
-  transition: width 0.3s ease;
 }
 
 .progress-points {
@@ -626,7 +609,6 @@ body::after {
   font-size: 16px;
   font-weight: 600;
   cursor: pointer;
-  transition: var(--transition);
   text-decoration: none;
 }
 
@@ -653,12 +635,6 @@ body::after {
   border: 3px solid #f3f3f3;
   border-top: 3px solid var(--primary-color);
   border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
 }
 
 /* Responsive Design */


### PR DESCRIPTION
## Summary

Added a step-by-step onboarding guide for the Team Ranking page to help new users understand page layout, team features, and weekly challenge workflow.

---

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Integration
- [ ] Documentation
- [ ] Refactor
- [ ] CI/CD

---

## Related Issue

Closes #

---

## Changes Made

- Implemented a 5-step interactive user guide for the Team Ranking page
- Added guide highlight effects for key sections: My Team, Weekly Challenge button, challenge panel, team ranking list, and guide button
- Integrated with the AcadBeatGuide SDK to support step navigation, auto-positioning, and forced click steps
- Added localStorage to track guide completion status (users only see it once by default)
- Added manual replay button to restart the guide at any time
- Added data-guide attributes to target elements for guide positioning
- Styled guide overlay, cards, and highlighted focus states
- Auto-scrolls to highlighted elements during guide steps
- Support skip, previous, next, and finish actions

---

## How Tested

- Manual end-to-end testing on the Team Ranking page
- Verified guide steps display, positioning, and auto-advance correctly
- Tested forced click interaction for the Weekly Challenge button
- Verified modal opens/closes correctly during guide flow
- Tested guide replay via the guide button
- Confirmed completion status is saved in localStorage
- Tested on both desktop and responsive layout